### PR TITLE
Bandaid fix getColorMode to work with more glass block names

### DIFF
--- a/src/main/java/com/seibel/distanthorizons/common/wrappers/block/ClientBlockStateColorCache.java
+++ b/src/main/java/com/seibel/distanthorizons/common/wrappers/block/ClientBlockStateColorCache.java
@@ -540,7 +540,7 @@ public class ClientBlockStateColorCache
 		{
 			if (block instanceof BlockLeavesBase) return Leaves;
 			if (block instanceof BlockFlower) return Flower;
-			if (block.toString().contains("glass")) return Glass;
+			if (block.toString().toLowerCase().contains("glass")) return Glass;
 			if (block.toString().equals("Block{chiselsandbits:chiseled}")) return Chisel;
 			return Default;
 		}


### PR DESCRIPTION
Fixes glass, clear glass, and some others from rendering as full blocks and instead makes them transparent as they should be.

Changed the function to catch more glass block types by comparing the block class names as lower case strings. This still will not catch things like EnderIO's fused quartz or ztones' glass (because the name is Ztones:tile.glax) so something more sophisticated and or having a file of glass block IDs would be better.

