### PR TITLE
Fix null pointer when serverName is null in MinecraftClientWrapper

### DIFF
--- a/src/main/java/com/seibel/distanthorizons/common/wrappers/minecraft/MinecraftClientWrapper.java
+++ b/src/main/java/com/seibel/distanthorizons/common/wrappers/minecraft/MinecraftClientWrapper.java
@@ -86,7 +86,7 @@ public class MinecraftClientWrapper implements IMinecraftClientWrapper, IMinecra
             return ClientOnlySaveStructure.REPLAY_SERVER_FOLDER_NAME;
         } else {
             ServerData server = MINECRAFT.func_147104_D();
-            return (server != null) ? server.serverName : "NULL";
+            return (server != null && server.serverName != null) ? server.serverName : "NULL";
         }
     }
 


### PR DESCRIPTION
Custom-Main-Menu mod's connectToServer action can leave server.serverName null, causing a NPE. Added a null check for serverName alongside the existing server null check.